### PR TITLE
Fix/street predirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Validation in order to show user when address is invalid
 
 ## [2.0.4] - 2023-06-14
 

--- a/checkout-ui-custom/checkout6-custom.css
+++ b/checkout-ui-custom/checkout6-custom.css
@@ -1,4 +1,5 @@
-.addressValidation__box {
+.addressValidation__box,
+.addressInvalidation__box {
   clear: both;
   padding: 5px 30px 30px 30px;
   background: #FFF;
@@ -9,7 +10,8 @@
   color: #333333;
 }
 
-button.addressValidation__box--button {
+button.addressValidation__box--button,
+button.js-addressCheck__box--button {
   background: #1a73e8;
   padding: 10px;
   display: inline-block;
@@ -17,10 +19,12 @@ button.addressValidation__box--button {
   border-radius: 3px;
   color: #fff;
 }
-.addressValidation__box--button.js-loading {
+.addressValidation__box--button.js-loading,
+.js-addressCheck__box--button.js-loading {
 	opacity: 0.8;
 }
-.addressValidation__box--button.js-loading:after {
+.addressValidation__box--button.js-loading:after,
+.js-addressCheck__box--button.js-loading:after {
   border: 3px solid #f3f3f3;
   border-top: 3px solid #1a73e8;
   border-radius: 50%;

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -39,30 +39,36 @@ class _addressValidation {
 			e.preventDefault()
 			e.stopPropagation()
 			_this.saveAddress()
-
 		})
 
-
+		$("body").on("click", ".js-addressCheck__box--button", function(e) {
+			e.preventDefault()
+			e.stopPropagation()
+      _this.desactiveAddressValidation();
+      _this.closeModal(".addressInvalidation__box")
+		})
 	}
 
-	closeModal() {
+	closeModal(selectedElement) {
 		const _this = this
-		$(".addressValidation__box").slideUp(500, function() {
-			$(".addressValidation__box").remove()
+
+		$(selectedElement).slideUp(500, function() {
+			$(selectedElement).remove()
 			_this._addressValidationStatus = true
 			//_this._addressValidationId = _this.orderForm.shippingData.selectedAddresses[0].addressId
+      if(selectedElement == ".addressInvalidation__box") {
+        $('body').addClass('v-custom-addressForm-on v-custom-googleForm-on')
+      }
 		})
 
     _this.desactiveAddressValidation();
-
-
 	}
 
 	showInvalidAddressModal() {
 		const _this = this
 
     const _modalHTML = `
-			<div class="addressValidation__box">
+			<div class="addressInvalidation__box">
 				<div class="addressValidation__box--wrap">
 					<h4 class="addressValidation__box--title">Address Verification</h4>
 					<p class="addressValidation__box--text">
@@ -70,13 +76,13 @@ class _addressValidation {
             <b>We couldn't find your address</b>
           </p>
 					<p class="addressValidation__box--text">Please review it. Bear in mind that we will might be unabled to send your order.</p>
-					<button class="addressValidation__box--button js-addressValidation__box--close">Continue with this address</button>
+					<button class="js-addressCheck__box--button js-addressValidation__box--close">Change Address</button>
 				</div>
 			</div>
 		`
 
-		if($(".addressValidation__box").length) return
-		$("body").append(_modalHTML)
+		if($(".addressInvalidation__box").length) return
+		$("#shipping-data").after(_modalHTML)
 	}
 
 	showModal() {
@@ -125,7 +131,7 @@ class _addressValidation {
 		const _this = this
 
 		if(!$(".addressValidation__box--addressOption--validated").hasClass("ischecked")) {
-			_this.closeModal()
+			_this.closeModal('.addressValidation__box')
       _this.desactiveAddressValidation();
 			return
 		}
@@ -196,7 +202,7 @@ class _addressValidation {
     vtexjs.checkout.sendAttachment("shippingData", {}).done(function(orderForm) {
       $("button.vtex-front-messages-close-all.close").trigger("click");
       $(".vtex-omnishipping-1-x-warning").hide();
-      _this.closeModal()
+      _this.closeModal(".addressValidation__box")
       vtexjs.checkout.sendAttachment("shippingData", shippingInfo).done(function(orderForm) {
         _this.desactiveAddressValidation()
         _this.triggerEvent("savedAddress")
@@ -262,17 +268,15 @@ class _addressValidation {
             _this.validatedAddress.delivery_line_1 === _this.checkoutAddress.street)
           ) return
 
-          debugger
-          if(_this.validatedAddress.analysis.dpv_footnotes.includes('A1')) {
-            debugger
-						_this.showInvalidAddressModal()
-          }
-
 					if(_this.validatedAddress.analysis.dpv_match_code) {
 						_this.showModal()
             _this.activeAddressValidation();
             _this.triggerEvent("showModal")
-					}
+					} else if(_this.validatedAddress.analysis.dpv_footnotes.includes('A1')) {
+						_this.showInvalidAddressModal()
+            _this.activeAddressValidation();
+            _this.triggerEvent("showModal")
+          }
 
 
           _this.ifAllUnavailable(_this.orderForm);
@@ -291,12 +295,10 @@ class _addressValidation {
 	}
 
   activeAddressValidation() {
-
     $("body").addClass("js-addressValidation-active")
   }
 
   desactiveAddressValidation() {
-
     $("body").removeClass("js-addressValidation-active")
   }
 

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -262,13 +262,16 @@ class _addressValidation {
             _this.validatedAddress.delivery_line_1 === _this.checkoutAddress.street)
           ) return
 
+          debugger
+          if(_this.validatedAddress.analysis.dpv_footnotes.includes('A1')) {
+            debugger
+						_this.showInvalidAddressModal()
+          }
 
-					if(_this.validatedAddress.analysis.dpv_match_code || _this.validatedAddress.analysis.dpv_footnotes=="A1") {
+					if(_this.validatedAddress.analysis.dpv_match_code) {
 						_this.showModal()
             _this.activeAddressValidation();
             _this.triggerEvent("showModal")
-					} else {
-						//_this.showInvalidAddressModal()
 					}
 
 

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -106,7 +106,7 @@ class _addressValidation {
 							<p>Suggested address:</p>
 							<input type="radio" name="addressvalidation" checked="checked"/>
 							<span>
-								${_this.validatedAddress.components.primary_number} ${_this.validatedAddress.components.street_name} ${_this.validatedAddress.components.street_suffix ? _this.validatedAddress.components.street_suffix : ""}
+								${_this.validatedAddress.components.primary_number} ${_this.validatedAddress.components.street_predirection !== undefined ? _this.validatedAddress.components.street_predirection : ''} ${_this.validatedAddress.components.street_name} ${_this.validatedAddress.components.street_suffix ? _this.validatedAddress.components.street_suffix : ""}
 								<br/>
 								${_this.validatedAddress.components.default_city_name === "Null" ? "" : _this.validatedAddress.components.default_city_name}, ${_this.validatedAddress.components.state_abbreviation} ${_this.validatedAddress.components.zipcode}
 							</span>
@@ -300,7 +300,7 @@ class _addressValidation {
 	compareSelectAddresses(oldOrderForm, orderFormUpdated) {
 		const _this = this
 
-		if(JSON.stringify(orderFormUpdated.shippingData.selectedAddresses[0]) !== JSON.stringify(oldOrderForm.shippingData.selectedAddresses[0])) {
+		if(JSON.stringify(orderFormUpdated?.shippingData?.selectedAddresses[0]) !== JSON.stringify(oldOrderForm?.shippingData?.selectedAddresses[0])) {
 			_this._addressValidationStatus = false
 		} else {
 			_this._addressValidationStatus = true

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.us-address-validation-checkout",
   "version": "2.0.4",
   "dependencies": {
-    "@vtex/api": "6.45.15",
+    "@vtex/api": "6.45.20",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",
@@ -20,7 +20,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.15",
+    "@vtex/api": "6.45.20",
     "@vtex/prettier-config": "^0.3.1",
     "@vtex/tsconfig": "^0.6.0",
     "tslint": "^5.12.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -235,10 +235,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.45.15":
-  version "6.45.15"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.15.tgz#aa987d22f7df16ce2861130deda6ffd63156817b"
-  integrity sha512-Rg1VGDzJ4hHUNp1vSidMdGGPojr1PikMTptlZsJ3oNZVdEo4cPx2l8ZcAEwHWORL7QjPjXaEgmeA5ZOSf+boCQ==
+"@vtex/api@6.45.20":
+  version "6.45.20"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.20.tgz#c1090249a424fd700499de3fed0d80d99ff53332"
+  integrity sha512-O7RJWWr4PfvixNpc0GgQh85iKcv9j1IKkpApwJQSW/WzxoTgSrcjYHOVUmJ1GWWBmRV/qvB2VaV6Ow1QL3UOCQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -258,7 +258,7 @@
     fs-extra "^7.0.0"
     graphql "^14.5.8"
     graphql-tools "^4.0.6"
-    graphql-upload "^8.1.0"
+    graphql-upload "^13.0.0"
     jaeger-client "^3.18.0"
     js-base64 "^2.5.1"
     koa "^2.11.0"
@@ -269,7 +269,7 @@
     mime-types "^2.1.12"
     opentracing "^0.14.4"
     p-limit "^2.2.0"
-    prom-client "^12.0.0"
+    prom-client "^14.2.0"
     qs "^6.5.1"
     querystring "^0.2.0"
     ramda "^0.26.0"
@@ -832,10 +832,10 @@ fresh@~0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-fs-capacitor@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-2.0.4.tgz#5a22e72d40ae5078b4fe64fe4d08c0d3fc88ad3c"
-  integrity sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==
+fs-capacitor@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-6.2.0.tgz#fa79ac6576629163cb84561995602d8999afb7f5"
+  integrity sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -898,15 +898,15 @@ graphql-tools@^4.0.6:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql-upload@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-8.1.0.tgz#6d0ab662db5677a68bfb1f2c870ab2544c14939a"
-  integrity sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==
+graphql-upload@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-13.0.0.tgz#1a255b64d3cbf3c9f9171fa62a8fb0b9b59bb1d9"
+  integrity sha512-YKhx8m/uOtKu4Y1UzBFJhbBGJTlk7k4CydlUUiNrtxnwZv0WigbRHP+DVhRNKt7u7DXOtcKZeYJlGtnMXvreXA==
   dependencies:
     busboy "^0.3.1"
-    fs-capacitor "^2.0.4"
-    http-errors "^1.7.3"
-    object-path "^0.11.4"
+    fs-capacitor "^6.2.0"
+    http-errors "^1.8.1"
+    object-path "^0.11.8"
 
 graphql@*:
   version "15.6.0"
@@ -978,7 +978,7 @@ http-errors@1.7.3:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@^1.3.1, http-errors@^1.6.3, http-errors@^1.7.3, http-errors@~1.8.0:
+http-errors@^1.3.1, http-errors@^1.6.3, http-errors@~1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.0.tgz#75d1bbe497e1044f51e4ee9e704a62f28d336507"
   integrity sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==
@@ -988,6 +988,17 @@ http-errors@^1.3.1, http-errors@^1.6.3, http-errors@^1.7.3, http-errors@~1.8.0:
     setprototypeof "1.2.0"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-errors@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
+  integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.1"
 
 humanize-ms@^1.2.1:
   version "1.2.1"
@@ -1397,7 +1408,7 @@ object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
   integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
 
-object-path@^0.11.4:
+object-path@^0.11.8:
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.8.tgz#ed002c02bbdd0070b78a27455e8ae01fc14d4742"
   integrity sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==
@@ -1480,10 +1491,10 @@ process@^0.10.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.10.1.tgz#842457cc51cfed72dc775afeeafb8c6034372725"
   integrity sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=
 
-prom-client@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-12.0.0.tgz#9689379b19bd3f6ab88a9866124db9da3d76c6ed"
-  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
+prom-client@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
   dependencies:
     tdigest "^0.1.1"
 
@@ -1616,7 +1627,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -1706,6 +1717,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+toidentifier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
 tokenbucket@^0.3.2:
   version "0.3.2"


### PR DESCRIPTION
## Description made:
Currently when user adds an address that doesn't exist, nothing happens. This will not let the user continue and will just let the user add a random address without any problem. 

## Fix
Add validation to check if the response includes `A1` in the `dpv_footnotes` to show the address not found. 

## Testing
You can test using [this workspace](https://alberto--andymark.myvtex.com/)

## Screenshot of changes:
![Image 2023-09-12 at 12 17 56 p m](https://github.com/vtex-apps/us-address-validation/assets/11176519/6500a9ec-7026-41ee-bd94-6019f060c2f1)
