### PR TITLE
Update us address validation suffix

### DIFF
--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -88,7 +88,6 @@ class _addressValidation {
 	showModal() {
 		const _this = this
 
-
 		const _modalHTML = `
 			<div class="addressValidation__box">
 				<div class="addressValidation__box--wrap">
@@ -112,7 +111,7 @@ class _addressValidation {
 							<p>Suggested address:</p>
 							<input type="radio" name="addressvalidation" checked="checked"/>
 							<span>
-								${_this.validatedAddress.components.primary_number} ${_this.validatedAddress.components.street_predirection !== undefined ? _this.validatedAddress.components.street_predirection : ''} ${_this.validatedAddress.components.street_name} ${_this.validatedAddress.components.street_suffix ? _this.validatedAddress.components.street_suffix : ""}
+								${_this.validatedAddress.components.primary_number} ${_this.validatedAddress.components.street_predirection !== undefined ? _this.validatedAddress.components.street_predirection : ''} ${_this.validatedAddress.components.street_name} ${_this.validatedAddress.components.street_postdirection ? _this.validatedAddress.components.street_postdirection : ""}
 								<br/>
 								${_this.validatedAddress.components.default_city_name === "Null" ? "" : _this.validatedAddress.components.default_city_name}, ${_this.validatedAddress.components.state_abbreviation} ${_this.validatedAddress.components.zipcode}
 							</span>

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.us-address-validation-checkout",
   "version": "2.0.5",
   "dependencies": {
-    "@vtex/api": "6.45.20",
+    "@vtex/api": "6.46.0",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",
@@ -20,7 +20,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.20",
+    "@vtex/api": "6.46.0",
     "@vtex/prettier-config": "^0.3.1",
     "@vtex/tsconfig": "^0.6.0",
     "tslint": "^5.12.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -235,10 +235,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.45.20":
-  version "6.45.20"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.20.tgz#c1090249a424fd700499de3fed0d80d99ff53332"
-  integrity sha512-O7RJWWr4PfvixNpc0GgQh85iKcv9j1IKkpApwJQSW/WzxoTgSrcjYHOVUmJ1GWWBmRV/qvB2VaV6Ow1QL3UOCQ==
+"@vtex/api@6.46.0":
+  version "6.46.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.0.tgz#208d14b96cbc8fd5eb6bd18fbd0c8424886e6154"
+  integrity sha512-XAvJlD1FG1GynhPXiMcayunahFCL2r3ilO5MHAWKxYvB/ljyxi4+U+rVpweeaQGpxHfhKHdfPe7qNEEh2oa2lw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
## Changes made:
Update response display from Smarty endpoint. 

## Description:
Looks like Smarty updated their `response fields` so we can to update what fields we were trying to display

## Screenshot of changes:
![Image 2023-11-09 at 10 29 44 a m](https://github.com/vtex-apps/us-address-validation/assets/11176519/9f7921d9-f430-46df-859d-cad4d666cca7)

## Where to test:
You can test [here](https://addressvalidation--alssports.myvtex.com/)