### PR TITLE
Validate only on shipping step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Validate address in checkout for only shipping selected
 
 ## [2.0.6] - 2023-11-09
 ### Fixed

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -247,6 +247,8 @@ class _addressValidation {
 				_this.checkoutAddress = _this.orderForm.shippingData.selectedAddresses[0]
 
         _this.triggerEvent("validate")
+      if(window.vtexjs.checkout.orderForm && window.vtexjs.checkout.orderForm.shippingData && window.vtexjs.checkout.orderForm.shippingData.logisticsInfo &&
+        window.vtexjs.checkout.orderForm.shippingData.logisticsInfo[0].selectedDeliveryChannel !== 'pickup-in-point') {
 				fetch(`/smartystreets-validation/?street=${_this.checkoutAddress.street}&city=${_this.checkoutAddress.city ? _this.checkoutAddress.city : _this.checkoutAddress.neighborhood}&state=${_this.checkoutAddress.state}&zipcode=${_this.checkoutAddress.postalCode}`,
 				{
           method: 'GET',
@@ -284,6 +286,7 @@ class _addressValidation {
 				.catch(function(e) {
           console.error(e);
         })
+      }
 
 
 			}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1627,7 +1627,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
## Changes made:
Add the address validation only for Delivery is selected not for Pick up in store. 

## Description:
This is an update to the app to only validate the address if the selected method is set for Delivery and not for Pickup

## Where to test:
You can test [here](https://alberto--alssports.myvtex.com/)
Add a product to your cart and enter an invalid address, you should be prompted to change the address only if selected method is Delivery